### PR TITLE
Add ability to include cell type

### DIFF
--- a/lib/rubyxls/version.rb
+++ b/lib/rubyxls/version.rb
@@ -1,3 +1,3 @@
 module Rubyxls
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/lib/rubyxls/workbook.rb
+++ b/lib/rubyxls/workbook.rb
@@ -54,17 +54,19 @@ module Rubyxls
       rows.each do |row|
         values = []
         widths = []
+        types = []
         styles = []
         height = nil
         row.each do |cell|
           values << cell[:value]
           widths << cell[:width]
+          types << cell[:type]
           styles << retrieve_style_code(cell[:style])
           height = cell[:height] if cell[:height]
           merge_cell(cell) if cell[:merge]
           @data_validations["#{cell[:column]}#{cell[:row]}"] = cell[:data_validation] if cell[:data_validation]
         end
-        @sheet.add_row(values, { style: styles, widths: widths, height: height })
+        @sheet.add_row(values, { types: types, style: styles, widths: widths, height: height })
       end
     end
 

--- a/spec/rubyxls_spec.rb
+++ b/spec/rubyxls_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Rubyxls do
 
   it 'has correct version number' do
-    expect(Rubyxls::VERSION).to eq("1.0.2")
+    expect(Rubyxls::VERSION).to eq("1.0.3")
   end
 
   describe '#generate_default_report' do


### PR DESCRIPTION
This gem is built on top of the axlsx gem. It includes the option to add a row with a `type`. Right now, there's no way to get a `type` through `rubyxls` to `axlsx1`. 

The issue I'm having is when a string has leading zeros like `000056` it's getting stripped to `56` and when a string has an 'e' in it like `35E4` it's getting converted to scientific notation. In the case of VTS, this is specifically happening when putting suite names into reports.

This gives us the ability to specify a cell type per the `axlsx` documentation: https://github.com/randym/axlsx/blob/master/examples/example.rb#L396